### PR TITLE
feat: implement Django user authentication system

### DIFF
--- a/accounts/admin.py
+++ b/accounts/admin.py
@@ -1,3 +1,16 @@
 from django.contrib import admin
+from django.contrib.auth.admin import UserAdmin as BaseUserAdmin
+from .models import User
 
-# Register your models here.
+@admin.register(User)
+class UserAdmin(BaseUserAdmin):
+    ordering = ("id",)
+    list_display = ("id", "email", "is_staff", "is_superuser", "created_at")
+    search_fields = ("email",)
+    fieldsets = (
+        (None, {"fields": ("email", "password")}),
+        ("권한", {"fields": ("is_active", "is_staff", "is_superuser", "groups", "user_permissions")}),
+    )
+    add_fieldsets = (
+        (None, {"classes": ("wide",), "fields": ("email", "password1", "password2")}),
+    )

--- a/accounts/forms.py
+++ b/accounts/forms.py
@@ -1,0 +1,51 @@
+from django import forms
+from django.contrib.auth.forms import UserCreationForm, AuthenticationForm
+from .models import User
+
+class SignupForm(UserCreationForm):
+    class Meta:
+        model = User
+        fields = ("email",)
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["email"].label = "이메일"
+        self.fields["password1"].label = "비밀번호"
+        self.fields["password2"].label = "비밀번호 확인"
+
+        self.fields["email"].widget = forms.EmailInput(attrs={
+            "class": "form-control",
+            "placeholder": "이메일",
+            "autocomplete": "email",
+        })
+        self.fields["password1"].widget.attrs.update({
+            "class": "form-control",
+            "placeholder": "비밀번호",
+            "autocomplete": "new-password",
+        })
+        self.fields["password2"].widget.attrs.update({
+            "class": "form-control",
+            "placeholder": "비밀번호 확인",
+            "autocomplete": "new-password",
+        })
+
+    def clean_email(self):
+        email = self.cleaned_data.get("email", "").strip().lower()
+        if not email:
+            raise forms.ValidationError("이메일은 필수입니다.")
+        if User.objects.filter(email=email).exists():
+            raise forms.ValidationError("이미 사용 중인 이메일입니다.")
+        return email
+
+class EmailAuthenticationForm(AuthenticationForm):
+    username = forms.EmailField(
+        label="이메일",
+        widget=forms.EmailInput(attrs={
+            "class": "form-control",
+            "placeholder": "이메일",
+            "autocomplete": "email",
+        })
+    )
+
+    def clean_username(self):
+        return self.cleaned_data["username"].strip().lower()

--- a/accounts/models.py
+++ b/accounts/models.py
@@ -1,3 +1,42 @@
 from django.db import models
+from django.contrib.auth.models import AbstractBaseUser, PermissionsMixin, BaseUserManager
 
-# Create your models here.
+class UserManager(BaseUserManager):
+    use_in_migrations = True
+
+    def _create_user(self, email, password, **extra_fields):
+        if not email:
+            raise ValueError("이메일은 필수입니다.")
+        email = self.normalize_email(email).lower().strip()
+        user = self.model(email=email, **extra_fields)
+        user.set_password(password)
+        user.save(using=self._db)
+        return user
+
+    def create_user(self, email, password=None, **extra_fields):
+        extra_fields.setdefault('is_staff', False)
+        extra_fields.setdefault('is_superuser', False)
+        return self._create_user(email, password, **extra_fields)
+
+    def create_superuser(self, email, password, **extra_fields):
+        extra_fields.setdefault('is_staff', True)
+        extra_fields.setdefault('is_superuser', True)
+        if extra_fields.get("is_staff") is not True:
+            raise ValueError("Superuser는 is_staff=True 여야 합니다.")
+        if extra_fields.get("is_superuser") is not True:
+            raise ValueError("Superuser는 is_superuser=True 여야 합니다.")
+        return self._create_user(email, password, **extra_fields)
+
+class User(AbstractBaseUser, PermissionsMixin):
+    email = models.EmailField(unique=True, db_index=True)
+    is_active = models.BooleanField(default=True)
+    is_staff = models.BooleanField(default=False)
+    created_at = models.DateTimeField(auto_now_add=True)
+
+    USERNAME_FIELD = 'email'
+    REQUIRED_FIELDS = []
+
+    objects = UserManager()
+
+    def __str__(self):
+        return self.email

--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -1,0 +1,10 @@
+from django.urls import path
+from .views import SignupView, SigninView, SignoutView
+
+app_name = "accounts"
+
+urlpatterns = [
+    path("signup/", SignupView.as_view(), name="signup"),
+    path("login/",  SigninView.as_view(), name="login"),
+    path("logout/", SignoutView.as_view(), name="logout"),
+]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -1,3 +1,24 @@
-from django.shortcuts import render
+from django.contrib.auth import login
+from django.contrib.auth.views import LoginView, LogoutView
+from django.shortcuts import render, redirect
+from django.views import View
+from .forms import SignupForm, EmailAuthenticationForm
 
-# Create your views here.
+class SignupView(View):
+    def get(self, request):
+        return render(request, "accounts/signup.html", {"form": SignupForm()})
+
+    def post(self, request):
+        form = SignupForm(request.POST)
+        if form.is_valid():
+            user = form.save()
+            login(request, user)
+            return redirect("/")
+        return render(request, "accounts/signup.html", {"form": form})
+
+class SigninView(LoginView):
+    template_name = "accounts/login.html"
+    authentication_form = EmailAuthenticationForm
+
+class SignoutView(LogoutView):
+    pass

--- a/opengallery/settings.py
+++ b/opengallery/settings.py
@@ -140,3 +140,8 @@ LOGIN_REDIRECT_URL = "/"
 # https://docs.djangoproject.com/en/5.2/ref/settings/#default-auto-field
 
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
+AUTH_USER_MODEL = "accounts.User"
+LOGIN_URL = "accounts/login"
+LOGIN_REDIRECT_URL = "/"
+LOGIN_REDIRECT_URL = "/"

--- a/opengallery/urls.py
+++ b/opengallery/urls.py
@@ -15,12 +15,13 @@ Including another URLconf
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
 from django.contrib import admin
-from django.urls import path
+from django.urls import path, include
 from django.conf import settings
 from django.conf.urls.static import static
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('accounts/', include('accounts.urls')),
 ]
 
 if settings.DEBUG:

--- a/templates/accounts/login.html
+++ b/templates/accounts/login.html
@@ -1,0 +1,27 @@
+<!doctype html>
+<html lang="ko">
+  <head><meta charset="utf-8"><title>로그인</title></head>
+  <body>
+    <h1>로그인</h1>
+
+    <form method="post" novalidate>
+      {% csrf_token %}
+      {{ form.non_field_errors }}
+
+      <p>
+        {{ form.username.label_tag }}<br>
+        {{ form.username }}<br>
+        {{ form.username.errors }}
+      </p>
+      <p>
+        {{ form.password.label_tag }}<br>
+        {{ form.password }}<br>
+        {{ form.password.errors }}
+      </p>
+
+      <button type="submit">로그인</button>
+    </form>
+
+    <p>처음이신가요? <a href="{% url 'accounts:signup' %}">회원가입</a></p>
+  </body>
+</html>

--- a/templates/accounts/signup.html
+++ b/templates/accounts/signup.html
@@ -1,0 +1,32 @@
+<!doctype html>
+<html lang="ko">
+  <head><meta charset="utf-8"><title>회원가입</title></head>
+  <body>
+    <h1>회원가입</h1>
+
+    <form method="post" novalidate>
+      {% csrf_token %}
+      {{ form.non_field_errors }}
+
+      <p>
+        {{ form.email.label_tag }}<br>
+        {{ form.email }}<br>
+        {{ form.email.errors }}
+      </p>
+      <p>
+        {{ form.password1.label_tag }}<br>
+        {{ form.password1 }}<br>
+        {{ form.password1.errors }}
+      </p>
+      <p>
+        {{ form.password2.label_tag }}<br>
+        {{ form.password2 }}<br>
+        {{ form.password2.errors }}
+      </p>
+
+      <button type="submit">가입</button>
+    </form>
+
+    <p>이미 계정이 있으신가요? <a href="{% url 'accounts:login' %}">로그인</a></p>
+  </body>
+</html>


### PR DESCRIPTION
- User 모델을 AbstractBaseUser와 PermissionsMixin을 상속하여 커스텀 구현
- 이메일을 기본 인증 필드로 사용하는 UserManager 추가
- 회원가입/로그인 폼을 Django 내장 폼을 상속하여 구현
- 일반 사용자와 관리자 계정을 구분하여 권한 설정
- accounts 앱을 INSTALLED_APPS에 등록하고 AUTH_USER_MODEL 설정
- 회원가입, 로그인, 로그아웃을 위한 뷰와 URL 패턴 구현