### PR TITLE
feat: add gallery artwork list page with search, pagination

### DIFF
--- a/gallery/urls.py
+++ b/gallery/urls.py
@@ -1,0 +1,8 @@
+from django.urls import path
+from .views import ArtworkListView
+
+app_name = "gallery"
+
+urlpatterns = [
+    path('artworks/', ArtworkListView.as_view(), name='artwork_list'),
+]

--- a/gallery/views.py
+++ b/gallery/views.py
@@ -1,3 +1,85 @@
-from django.shortcuts import render
+from django.views.generic import ListView
+from django.db.models import Q
+from django.utils.http import urlencode
+from .models import Artwork
 
-# Create your views here.
+class ArtworkListView(ListView):
+    model = Artwork
+    template_name = "gallery/artwork_list.html"
+    context_object_name = "artworks"
+    paginate_by = 24
+    ordering = ["-created_at", "-id"]
+
+    @staticmethod
+    def _to_int_or_none(value):
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+
+    def get_queryset(self):
+        queryset = super().get_queryset()
+
+        title = (self.request.GET.get("title") or "").strip()
+        price_min = self._to_int_or_none(self.request.GET.get("price_min"))
+        price_max = self._to_int_or_none(self.request.GET.get("price_max"))
+        size_min = self._to_int_or_none(self.request.GET.get("size_min"))
+        size_max = self._to_int_or_none(self.request.GET.get("size_max"))
+
+        if price_min is not None and price_min < 0:
+            price_min = 0
+        if price_max is not None and price_max < 0:
+            price_max = 0
+        if size_min is not None:
+            size_min = max(1, size_min)
+        if size_max is not None:
+            size_max = min(500, size_max)
+
+        filters = Q()
+        if title:
+            queryset = queryset.filter(title__icontains=title)
+        if price_min is not None:
+            queryset = queryset.filter(price__gte=price_min)
+        if price_max is not None:
+            queryset = queryset.filter(price__lte=price_max)
+        if size_min is not None:
+            queryset = queryset.filter(size__gte=size_min)
+        if size_max is not None:
+            queryset = queryset.filter(size__lte=size_max)
+
+        if filters:
+            queryset = queryset.filter(filters)
+        return queryset
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+
+        title = (self.request.GET.get("title") or "").strip()
+        price_min = self._to_int_or_none(self.request.GET.get("price_min"))
+        price_max = self._to_int_or_none(self.request.GET.get("price_max"))
+        size_min = self._to_int_or_none(self.request.GET.get("size_min"))
+        size_max = self._to_int_or_none(self.request.GET.get("size_max"))
+
+        context.update({
+            "title": title,
+            "price_min": price_min if price_min is not None else "",
+            "price_max": price_max if price_max is not None else "",
+            "size_min": size_min if size_min is not None else "",
+            "size_max": size_max if size_max is not None else "",
+        })
+
+        page_obj = context.get("page_obj")
+        if page_obj:
+            paginator = page_obj.paginator
+            context["page_range"] = paginator.get_elided_page_range(
+                number=page_obj.number, on_each_side=1, on_ends=1
+            )
+
+        preserved_params = {}
+        for key in ["title", "price_min", "price_max", "size_min", "size_max"]:
+            value = self.request.GET.get(key)
+            if value not in [None, ""]:
+                preserved_params[key] = value
+        context["preserved_query"] = urlencode(preserved_params)
+
+        return context

--- a/opengallery/urls.py
+++ b/opengallery/urls.py
@@ -25,6 +25,7 @@ urlpatterns = [
     path('', include('core.urls')),
     path('artist/', include('artist.urls')),
     path('admin/', include('admin_panel.urls')),
+    path('gallery/', include('gallery.urls')),
 
 ]
 

--- a/static/css/base.css
+++ b/static/css/base.css
@@ -1,17 +1,39 @@
+/* ----------------------------------
+   Global typography & layout
+---------------------------------- */
 body,
 form,
 form input,
 form select,
 form textarea,
 form button {
-    font-family: 'Noto Sans KR', sans-serif;
-    font-weight: 300;
+  font-family: 'Noto Sans KR', sans-serif;
+  font-weight: 300;
 }
 
 body {
-    padding-top: 80px;
+  padding-top: 80px;
 }
 
+/* ----------------------------------
+   Colors & utilities override
+---------------------------------- */
+.text-dark {
+  color: #222222 !important;
+}
+
+.bg-dark {
+  background-color: #222222 !important;
+}
+
+.object-cover {
+  object-fit: cover;
+  object-position: center;
+}
+
+/* ----------------------------------
+   Navbar
+---------------------------------- */
 .header-shadow {
   box-shadow: 0 4px 4px rgba(0, 0, 0, 0.06);
 }
@@ -21,85 +43,95 @@ body {
   padding-bottom: 1.2rem;
 }
 
-.text-dark {
-  color: #222222 !important;
-}
-
-.bg-dark {
-  background-color: #222222 !important;
-}
 .navbar-toggler.no-border {
   border: none;
   box-shadow: none;
 }
+
 .navbar-toggler.no-border:focus {
   outline: none;
   box-shadow: none;
 }
 
+/* ----------------------------------
+   Form controls
+---------------------------------- */
 .form-control {
-    border-radius: 0;
+  border-radius: 0;
 }
 
 .btn-submit {
-    padding-top: 0.7rem;
-    padding-bottom: 0.7rem;
-    margin-top: 2rem;
+  padding: 0.7rem 0;
+  margin-top: 2rem;
 }
 
 .form-title {
-    padding-top: 1.5rem;
-    padding-bottom: 1.5rem;
+  padding: 1.5rem 0;
 }
 
 .form-label {
-    font-size: 12px;
-    color: #989898;
+  font-size: 12px;
+  color: #989898;
 }
 
+/* ----------------------------------
+   Alerts
+---------------------------------- */
 .alert {
-    background-color: rgb(195, 168, 116) !important;
-    color: white !important;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
+  background-color: rgb(195, 168, 116) !important;
+  color: #fff !important;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
 .alert .btn-close {
-    margin-left: auto;
-    filter: invert(1) grayscale(100%) brightness(200%);
-    opacity: 1;
+  margin-left: auto;
+  filter: invert(1) grayscale(100%) brightness(200%);
+  opacity: 1;
 }
 
 .alert .btn-close:focus,
 .alert .btn-close:active {
-    outline: none;
-    box-shadow: none;
+  outline: none;
+  box-shadow: none;
 }
 
-.admin-sidebar .list-group-item { background: transparent; border: 0; padding-left: 0; padding-right: 0; }
-.admin-sidebar a.fw-semibold { color:#000; }
+/* ----------------------------------
+   Sidebar (Admin)
+---------------------------------- */
+.admin-sidebar .list-group-item {
+  background: transparent;
+  border: 0;
+  padding-left: 0;
+  padding-right: 0;
+}
 
+.admin-sidebar a.fw-semibold {
+  color: #000;
+}
+
+/* ----------------------------------
+   Dropdown menus
+---------------------------------- */
 .dropdown-menu .dropdown-item.active,
 .dropdown-menu .dropdown-item:active,
 .dropdown-menu .dropdown-submenu .dropdown-item.active,
 .dropdown-menu .dropdown-submenu .dropdown-item:active {
-    background-color: #212529 !important;
-    color: #fff !important;
+  background-color: #212529 !important;
+  color: #fff !important;
 }
-
 
 .dropdown-menu .dropdown-item:hover,
 .dropdown-menu .dropdown-item:focus,
 .dropdown-menu .dropdown-submenu .dropdown-item:hover,
 .dropdown-menu .dropdown-submenu .dropdown-item:focus {
-    background-color: #343a40 !important;
-    color: #fff !important;
+  background-color: #343a40 !important;
+  color: #fff !important;
 }
 
 .dropdown-menu .active > a,
 .dropdown-menu .active > button {
-    background-color: #212529 !important;
-    color: #fff !important;
+  background-color: #212529 !important;
+  color: #fff !important;
 }
-.object-cover { object-fit: cover; object-position: center; }

--- a/static/js/utils/price-comma.js
+++ b/static/js/utils/price-comma.js
@@ -1,0 +1,17 @@
+(function () {
+  function formatPriceCommas() {
+    document.querySelectorAll('.price-commas').forEach(el => {
+      const raw = el.getAttribute('data-price') || el.textContent;
+      const n = parseInt(String(raw).replace(/[^\d]/g, ''), 10);
+      el.textContent = Number.isFinite(n) ? n.toLocaleString('ko-KR') : raw;
+    });
+  }
+
+  if (document.readyState !== "loading") {
+    formatPriceCommas();
+  } else {
+    document.addEventListener("DOMContentLoaded", formatPriceCommas);
+  }
+
+  window.formatPriceCommas = formatPriceCommas;
+})();

--- a/templates/admin_panel/artist_stats.html
+++ b/templates/admin_panel/artist_stats.html
@@ -133,15 +133,4 @@
             </ul>
         </nav>
     {% endif %}
-
-    <script>
-        (function () {
-            document.querySelectorAll('.price-commas').forEach(el => {
-                const raw = el.getAttribute('data-price') || el.textContent;
-                const n = parseInt(String(raw).replace(/[^\d]/g, ''), 10);
-                el.textContent = Number.isFinite(n) ? n.toLocaleString('ko-KR') : raw;
-            });
-        })();
-    </script>
-
 {% endblock %}

--- a/templates/artist/dashboard.html
+++ b/templates/artist/dashboard.html
@@ -44,80 +44,85 @@
     </div>
 
 
-<h2 class="h5 mt-5 my-5">등록된 작품</h2>
-  {% if artworks %}
-    <div class="row g-3">
-      {% for art in artworks %}
-        <div class="col-6 col-md-4 col-lg-3">
-          <div class="card h-100 border-0">
-            <div class="ratio ratio-4x3 overflow-hidden">
-              {% if art.image %}
-                <img src="{{ art.image.url }}" class="w-100 h-100 object-cover" alt="{{ art.title }}">
-              {% else %}
-                <div class="w-100 h-100 d-flex align-items-center justify-content-center bg-light">
-                  <span class="text-muted small">이미지 없음</span>
+    <h2 class="h5 mt-5 my-5">등록된 작품</h2>
+    {% if artworks %}
+        <div class="row g-3">
+            {% for art in artworks %}
+                <div class="col-6 col-md-4 col-lg-3">
+                    <div class="card h-100 border-1 rounded-0">
+                        <div class="ratio ratio-4x3 overflow-hidden border-bottom">
+                            {% if art.image %}
+                                <img src="{{ art.image.url }}" class="w-100 h-100 object-cover" alt="{{ art.title }}">
+                            {% else %}
+                                <div class="w-100 h-100 d-flex align-items-center justify-content-center bg-light">
+                                    <span class="text-muted small">이미지 없음</span>
+                                </div>
+                            {% endif %}
+                        </div>
+                        <div class="card-body p-3">
+                            <div class="fw-semibold text-truncate" title="{{ art.title }}">{{ art.title }}</div>
+                            <div class="text-muted small mt-1">
+                                <span>{{ art.size }}호</span>
+                            </div>
+                            <div class="text-muted small mt-1">
+                                <span>작품가 <span class="price-commas" data-price="{{ art.price }}">{{ art.price }}</span>원</span>
+                            </div>
+                        </div>
+                    </div>
                 </div>
-              {% endif %}
-            </div>
-            <div class="card-body p-2">
-              <div class="fw-semibold text-truncate" title="{{ art.title }}">{{ art.title }}</div>
-              <div class="text-muted small mt-1">
-                  <span>{{ art.size }}호</span> |
-                  <span>작품가 <span class="price-commas" data-price="{{ art.price }}">{{ art.price }}</span>원</span>
-              </div>
-            </div>
-          </div>
+            {% endfor %}
         </div>
-      {% endfor %}
-    </div>
-  {% else %}
-    <div class="text-muted">등록된 작품이 없습니다. 상단 통계의 ‘작품 수’를 눌러 작품을 등록해 보세요. <a href="{% url 'artist:artwork_apply' %}">작품을 등록</a>해보세요.</div></div>
-  {% endif %}
+    {% else %}
+        <div class="text-muted">등록된 작품이 없습니다.</div>
+    {% endif %}
 
 
-  <h2 class="h5 mt-5 my-5">등록된 전시</h2>
-  {% if exhibitions %}
-    <div class="row g-3">
-      {% for ex in exhibitions %}
-        <div class="col-6 col-md-4 col-lg-3">
-          <div class="card h-100 border-0">
-            <div class="ratio ratio-4x3 overflow-hidden">
-              {% if ex.image %}
-                <img src="{{ ex.image.url }}" class="w-100 h-100 object-cover" alt="{{ ex.title }}">
-              {% else %}
-                <div class="w-100 h-100 d-flex align-items-center justify-content-center bg-light">
-                  <span class="text-muted small">이미지 없음</span>
+    <h2 class="h5 mt-5 my-5">등록된 전시</h2>
+    {% if exhibitions %}
+        <div class="row g-3">
+            {% for ex in exhibitions %}
+                <div class="col-6 col-md-4 col-lg-3">
+                    <div class="card h-100 border-1 rounded-0">
+                        <div class="ratio ratio-4x3 overflow-hidden border-bottom">
+                            {% if ex.image %}
+                                <img src="{{ ex.image.url }}" class="w-100 h-100 object-cover" alt="{{ ex.title }}">
+                            {% else %}
+                                <div class="w-100 h-100 d-flex align-items-center justify-content-center bg-light">
+                                    <span class="text-muted small">이미지 없음</span>
+                                </div>
+                            {% endif %}
+                        </div>
+                        <div class="card-body p-3">
+                            <div class="fw-semibold text-truncate" title="{{ ex.title }}">{{ ex.title }}</div>
+                            <div class="text-muted small mt-1">
+                                {{ ex.start_date|date:"Y.m.d" }} ~ {{ ex.end_date|date:"Y.m.d" }}
+                            </div>
+                        </div>
+                    </div>
                 </div>
-              {% endif %}
-            </div>
-            <div class="card-body p-2">
-              <div class="fw-semibold text-truncate" title="{{ ex.title }}">{{ ex.title }}</div>
-              <div class="text-muted small mt-1">
-                {{ ex.start_date|date:"Y.m.d" }} ~ {{ ex.end_date|date:"Y.m.d" }}
-              </div>
-            </div>
-          </div>
+            {% endfor %}
         </div>
-      {% endfor %}
-    </div>
-  {% else %}
-  <div class="text-muted">등록된 전시가 없습니다. <a href="{% url 'artist:exhibition_apply' %}">전시를 등록</a>해보세요.</div>
-  {% endif %}
+    {% else %}
+        <div class="text-muted">등록된 전시가 없습니다.</div>
+    {% endif %}
 
 
 
-<style>
-  .object-cover { object-fit: cover; object-position: center; }
-</style>
+    <style>
+        .object-cover {
+            object-fit: cover;
+            object-position: center;
+        }
+    </style>
 
-<script>
-  (function () {
-    document.querySelectorAll('.price-commas').forEach(el => {
-      const raw = el.getAttribute('data-price') || el.textContent;
-      const n = parseInt(String(raw).replace(/[^\d]/g, ''), 10);
-      el.textContent = Number.isFinite(n) ? n.toLocaleString('ko-KR') : raw;
-    });
-  })();
-</script>
+    <script>
+        (function () {
+            document.querySelectorAll('.price-commas').forEach(el => {
+                const raw = el.getAttribute('data-price') || el.textContent;
+                const n = parseInt(String(raw).replace(/[^\d]/g, ''), 10);
+                el.textContent = Number.isFinite(n) ? n.toLocaleString('ko-KR') : raw;
+            });
+        })();
+    </script>
 
 {% endblock %}

--- a/templates/artist/dashboard.html
+++ b/templates/artist/dashboard.html
@@ -105,24 +105,4 @@
     {% else %}
         <div class="text-muted">등록된 전시가 없습니다.</div>
     {% endif %}
-
-
-
-    <style>
-        .object-cover {
-            object-fit: cover;
-            object-position: center;
-        }
-    </style>
-
-    <script>
-        (function () {
-            document.querySelectorAll('.price-commas').forEach(el => {
-                const raw = el.getAttribute('data-price') || el.textContent;
-                const n = parseInt(String(raw).replace(/[^\d]/g, ''), 10);
-                el.textContent = Number.isFinite(n) ? n.toLocaleString('ko-KR') : raw;
-            });
-        })();
-    </script>
-
 {% endblock %}

--- a/templates/common/base.html
+++ b/templates/common/base.html
@@ -39,6 +39,7 @@
         integrity="sha384-ndDqU0Gzau9qJ1lfW4pNLlhNTkCfHzAVBReH9diLvGRem5+R9g2FzA8ZGN954O5Q"
         crossorigin="anonymous"></script>
 <script src="https://cdn.jsdelivr.net/npm/jquery@3.7.1/dist/jquery.min.js"></script>
+<script src="{% static 'js/utils/price-comma.js' %}"></script>
 {% block javascript %}{% endblock %}
 </body>
 </html>

--- a/templates/common/header.html
+++ b/templates/common/header.html
@@ -14,7 +14,7 @@
         <div class="collapse navbar-collapse">
             <ul class="navbar-nav me-auto gap-lg-2">
                 <li class="nav-item"><a class="nav-link" href="">작가목록</a></li>
-                <li class="nav-item"><a class="nav-link" href="">작품목록</a></li>
+                <li class="nav-item"><a class="nav-link" href="{% url 'gallery:artwork_list' %}">작품목록</a></li>
                 <li class="nav-item"><a class="nav-link" href="{% url 'artist:apply' %}">작가등록</a></li>
             </ul>
 

--- a/templates/common/layout/single_content.html
+++ b/templates/common/layout/single_content.html
@@ -3,16 +3,17 @@
 {% block title %}{% if block.super %}{{ block.super }}{% endif %}{% endblock %}
 
 {% block content %}
-  <section class="mt-3">
-    <header class="d-flex align-items-center justify-content-between mb-3">
-      <h1 class="h4 m-0">{% block page_title %}{% endblock %}</h1>
-      {% block page_actions %}{% endblock %}
-    </header>
-
-    <div class="card rounded-0 shadow-0 border-0">
-      <div class="card-body p-3 p-md-4">
-        {% block main %}{% endblock %}
-      </div>
-    </div>
-  </section>
+    <section class="mt-3">
+        <header class="mb-3 text-center">
+            <h1 class="h4 m-0">{% block page_title %}{% endblock %}</h1>
+            <div class="mt-2">
+                {% block page_actions %}{% endblock %}
+            </div>
+        </header>
+        <div class="card rounded-0 shadow-0 border-0">
+            <div class="card-body p-3 p-md-4">
+                {% block main %}{% endblock %}
+            </div>
+        </div>
+    </section>
 {% endblock %}

--- a/templates/common/layout/single_content.html
+++ b/templates/common/layout/single_content.html
@@ -1,0 +1,18 @@
+{% extends "common/base.html" %}
+
+{% block title %}{% if block.super %}{{ block.super }}{% endif %}{% endblock %}
+
+{% block content %}
+  <section class="mt-3">
+    <header class="d-flex align-items-center justify-content-between mb-3">
+      <h1 class="h4 m-0">{% block page_title %}{% endblock %}</h1>
+      {% block page_actions %}{% endblock %}
+    </header>
+
+    <div class="card rounded-0 shadow-0 border-0">
+      <div class="card-body p-3 p-md-4">
+        {% block main %}{% endblock %}
+      </div>
+    </div>
+  </section>
+{% endblock %}

--- a/templates/common/menu.html
+++ b/templates/common/menu.html
@@ -1,36 +1,39 @@
-<div class="offcanvas offcanvas-start" tabindex="-1" id="siteMenu" aria-labelledby="siteMenuLabel">
-  <div class="offcanvas-header">
-    <h2 class="offcanvas-title h5" id="siteMenuLabel">메뉴</h2>
-    <button type="button" class="btn-close" data-bs-dismiss="offcanvas" aria-label="닫기"></button>
-  </div>
-
-  <div class="offcanvas-body d-flex flex-column">
-    <ul class="list-unstyled mb-4">
-      <li><a class="d-block py-2 link-dark fw-semibold" href="{% url 'core:main' %}">홈</a></li>
-{#      <li><a class="d-block py-2 link-dark" href="{% url 'artworks:list' %}">작품보기</a></li>#}
-{#      <li><a class="d-block py-2 link-dark" href="{% url 'rentals:guide' %}">렌탈하기</a></li>#}
-{#      <li><a class="d-block py-2 link-dark" href="{% url 'reviews:list' %}">이용후기</a></li>#}
-{#      <li><a class="d-block py-2 link-dark" href="{% url 'artists:list' %}">작가</a></li>#}
-{#      <li><a class="d-block py-2 link-dark" href="{% url 'curations:list' %}">큐레이터추천</a></li>#}
-{#      <li><a class="d-block py-2 link-dark" href="{% url 'magazine:list' %}">아트매거진</a></li>#}
-    </ul>
-
-    <hr>
-
-    <ul class="list-unstyled mb-4">
-{#      <li><a class="d-block py-2 link-dark" href="{% url 'accounts:dashboard' %}">마이페이지</a></li>#}
-    </ul>
-
-    <div class="mt-auto d-grid gap-2">
-      {% if user.is_authenticated %}
-          <form action="{% url 'accounts:logout' %}" method="post" style="display:inline;">
-              {% csrf_token %}
-              <button type="submit" class="btn btn-outline-secondary">로그아웃</button>
-          </form>
-      {% else %}
-        <a class="btn btn-primary" href="{% url 'accounts:signup' %}">회원가입</a>
-        <a class="btn btn-outline-secondary" href="{% url 'accounts:login' %}">로그인</a>
-      {% endif %}
+<div class="offcanvas offcanvas-start" tabindex="-1" id="siteMenu" aria-labelledby="siteMenuLabel"
+     data-bs-scroll="true">
+    <div class="offcanvas-header">
+        <h2 class="offcanvas-title h5 m-0" id="siteMenuLabel">메뉴</h2>
+        <button type="button" class="btn-close" aria-label="닫기"></button>
     </div>
-  </div>
+
+    <div class="offcanvas-body d-flex flex-column">
+        <ul class="list-unstyled mb-4">
+            <li><a class="d-block py-2 link-dark fw-semibold" href="{% url 'core:main' %}">홈</a></li>
+            <li><a class="d-block py-2 link-dark" href="">작가목록</a></li>
+            <li><a class="d-block py-2 link-dark" href="{% url 'gallery:artwork_list' %}">작품목록</a></li>
+            <li><a class="d-block py-2 link-dark" href="{% url 'artist:apply' %}">작가등록</a></li>
+        </ul>
+        <hr>
+        <ul class="list-unstyled mb-4">
+            {% if user.is_authenticated %}
+                {% if user.is_approved_artist %}
+                    <li><a class="d-block py-2 link-dark" href="{% url 'artist:dashboard' %}">작가페이지</a></li>
+                {% endif %}
+                {% if user.is_staff %}
+                    <li><a class="d-block py-2 link-dark" href="{% url 'admin_panel:dashboard' %}">관리자페이지</a></li>
+                {% endif %}
+            {% else %}
+            {% endif %}
+        </ul>
+        <div class="mt-auto d-grid gap-2">
+            {% if user.is_authenticated %}
+                <form action="{% url 'accounts:logout' %}" method="post" class="d-grid">
+                    {% csrf_token %}
+                    <button type="submit" class="btn btn-outline-dark w-100">로그아웃</button>
+                </form>
+            {% else %}
+                <a class="btn btn-outline-dark w-100" href="{% url 'accounts:login' %}">로그인</a>
+                <a class="btn btn-dark w-100" href="{% url 'accounts:signup' %}">회원가입</a>
+            {% endif %}
+        </div>
+    </div>
 </div>

--- a/templates/gallery/artwork_list.html
+++ b/templates/gallery/artwork_list.html
@@ -1,0 +1,161 @@
+{% extends "common/layout/single_content.html" %}
+
+{% block title %} - 작품 목록{% endblock %}
+{% block page_title %}작품 목록{% endblock %}
+{% block page_actions %}{% endblock %}
+
+{% block main %}
+
+    <form id="search-form" method="get" class="mb-3" role="search" novalidate>
+        <div class="row g-2">
+            <div class="col-12">
+                <div class="input-group">
+                    <span class="input-group-text rounded-0">제목</span>
+                    <input class="form-control" type="text" name="title" value="{{ title }}" placeholder="작품 제목">
+                </div>
+            </div>
+            <div class="col-12 col-md-6">
+                <div class="input-group">
+                    <span class="input-group-text rounded-0">작품가</span>
+
+                    <input class="form-control" id="price-min-display" inputmode="numeric" placeholder="최소">
+                    <input type="hidden" id="price-min-input" name="price_min" value="{{ price_min }}">
+                    <span class="input-group-text">원</span>
+
+                    <span class="input-group-text">~</span>
+
+                    <input class="form-control" id="price-max-display" inputmode="numeric" placeholder="최대">
+                    <input type="hidden" id="price-max-input" name="price_max" value="{{ price_max }}">
+                    <span class="input-group-text rounded-0">원</span>
+                </div>
+            </div>
+            <div class="col-12 col-md-6">
+                <div class="input-group">
+                    <span class="input-group-text rounded-0">사이즈</span>
+                    <input class="form-control" type="number" name="size_min" min="1" max="500" value="{{ size_min }}"
+                           placeholder="최소 1호">
+                    <span class="input-group-text">호</span>
+                    <span class="input-group-text">~</span>
+                    <input class="form-control" type="number" name="size_max" min="1" max="500" value="{{ size_max }}"
+                           placeholder="최대 500호">
+                    <span class="input-group-text rounded-0">호</span>
+                </div>
+            </div>
+        </div>
+    <div class="d-flex justify-content-end mt-4 mb-4">
+        <div class="btn-group" role="group" aria-label="검색 및 초기화">
+            <button class="btn btn-dark rounded-0" type="submit">
+                <i class="bi bi-search me-1"></i>검색
+            </button>
+            <a class="btn btn-outline-secondary rounded-0" href="{{ request.path }}">초기화</a>
+        </div>
+    </div>
+    </form>
+
+    {% if artworks %}
+        <div class="row g-3">
+            {% for art in artworks %}
+                <div class="col-6 col-md-4 col-lg-3">
+                    <div class="card h-100 border-1 rounded-0">
+                        <div class="ratio ratio-4x3 overflow-hidden border-bottom">
+                            {% if art.image %}
+                                <img src="{{ art.image.url }}" class="w-100 h-100 object-cover" alt="{{ art.title }}">
+                            {% else %}
+                                <div class="w-100 h-100 d-flex align-items-center justify-content-center bg-light">
+                                    <span class="text-muted small">이미지 없음</span>
+                                </div>
+                            {% endif %}
+                        </div>
+                        <div class="card-body p-3">
+                            <div class="fw-semibold text-truncate" title="{{ art.title }}">{{ art.title }}</div>
+                            <div class="text-muted small mt-1"><span>{{ art.size }}호</span></div>
+                            <div class="text-muted small mt-1">
+                                작품가 <span class="price-commas" data-price="{{ art.price }}">{{ art.price }}</span>원
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            {% endfor %}
+        </div>
+    {% else %}
+        <div class="text-muted">조건에 일치하는 작품이 없습니다.</div>
+    {% endif %}
+
+    {% if is_paginated %}
+        <nav aria-label="Page navigation" class="my-4">
+            <ul class="pagination justify-content-center pagination-sm">
+                {% if page_obj.has_previous %}
+                    <li class="page-item">
+                        <a class="page-link text-dark"
+                           href="?page={{ page_obj.previous_page_number }}{% if preserved_query %}&{{ preserved_query }}{% endif %}">
+                            이전
+                        </a>
+                    </li>
+                {% else %}
+                    <li class="page-item disabled"><span class="page-link text-dark">이전</span></li>
+                {% endif %}
+
+                {% for num in page_range %}
+                    {% if num == page_obj.paginator.ELLIPSIS %}
+                        <li class="page-item disabled"><span class="page-link text-dark">&hellip;</span></li>
+                    {% elif num == page_obj.number %}
+                        <li class="page-item active"><span class="page-link bg-dark border-dark">{{ num }}</span></li>
+                    {% else %}
+                        <li class="page-item">
+                            <a class="page-link text-dark"
+                               href="?page={{ num }}{% if preserved_query %}&{{ preserved_query }}{% endif %}">{{ num }}</a>
+                        </li>
+                    {% endif %}
+                {% endfor %}
+
+                {% if page_obj.has_next %}
+                    <li class="page-item">
+                        <a class="page-link text-dark"
+                           href="?page={{ page_obj.next_page_number }}{% if preserved_query %}&{{ preserved_query }}{% endif %}">
+                            다음
+                        </a>
+                    </li>
+                {% else %}
+                    <li class="page-item disabled"><span class="page-link text-dark">다음</span></li>
+                {% endif %}
+            </ul>
+        </nav>
+    {% endif %}
+    <script>
+        (function () {
+            function priceFieldComma(displayId, realId) {
+                const display = document.getElementById(displayId);
+                const real = document.getElementById(realId);
+
+                function setInitial() {
+                    if (!display || !real) return;
+                    const n = parseInt(real.value, 10);
+                    display.value = Number.isFinite(n) ? n.toLocaleString('ko-KR') : '';
+                }
+
+                function syncFromDisplay() {
+                    const digits = (display.value || '').replace(/[^\d]/g, '');
+                    if (digits.length) {
+                        const n = parseInt(digits, 10);
+                        display.value = Number.isFinite(n) ? n.toLocaleString('ko-KR') : '';
+                        real.value = Number.isFinite(n) ? n : '';
+                    } else {
+                        display.value = '';
+                        real.value = '';
+                    }
+                }
+
+                if (display && real) {
+                    setInitial();
+                    display.addEventListener('input', syncFromDisplay);
+                    display.addEventListener('blur', syncFromDisplay);
+                    display.form && display.form.addEventListener('submit', syncFromDisplay);
+                }
+            }
+
+            priceFieldComma('price-min-display', 'price-min-input');
+            priceFieldComma('price-max-display', 'price-max-input');
+        })();
+    </script>
+
+{% endblock %}


### PR DESCRIPTION
- 작품 목록 페이지를 구현하여 등록된 작품들을 최신순으로 조회
- 제목, 가격, 호수 기반의 검색 기능을 추가
- 페이지네이션을 적용하여 한 페이지에서 많은 데이터를 처리하지 않도록 개선
- artwork_list.html 템플릿을 구성하여 카드 스타일 UI로 작품 목록을 표시
- views.py에 작품 목록 뷰 및 검색/페이징 로직 추가
- URL 라우팅을 통해 `/gallery/artworks/` 경로에서 접근 가능하도록 설정