### PR TITLE
fix: edit indentation of transaction.atomic() in multiple reject

### DIFF
--- a/artist/service.py
+++ b/artist/service.py
@@ -77,13 +77,13 @@ def process_multiple_reject(application_ids, admin_user):
 
     with transaction.atomic():
         applications = (ArtistApplication.objects.select_for_update().filter(pk__in=application_ids,
-                                                                             status__in=["PENDING", "ERROR"]))
-    processed = list(applications.values_list('id', flat=True))
-    applications.update(
-        status="REJECTED",
-        processed_by=admin_user,
-        processed_at=timezone.now(),
-    )
+                                                                                 status__in=["PENDING", "ERROR"]))
+        processed = list(applications.values_list('id', flat=True))
+        applications.update(
+            status="REJECTED",
+            processed_by=admin_user,
+            processed_at=timezone.now(),
+        )
 
     result.rejected.extend(processed)
     result.skipped.extend(set(application_ids) - set(processed))


### PR DESCRIPTION
[변경사항]

- 병렬 reject 시 오류가 발생하던 사항 수정
- 들여쓰기로 인하여 select_for_update가 transaction 내 없는 문제로 인함.